### PR TITLE
Update OAuth callback URL scheme to app.contextmcp

### DIFF
--- a/Context/Context/Authentication/AuthenticationFeature.swift
+++ b/Context/Context/Authentication/AuthenticationFeature.swift
@@ -25,7 +25,7 @@ struct AuthenticationFeature {
 
     // OAuth parameters
     var clientID = "com.indragie.Context"  // Made mutable for dynamic registration
-    let redirectURI = "context://oauth/callback"
+    let redirectURI = OAuthConstants.callbackURL.absoluteString
     var oAuthState: OAuthClient.StateParameter?  // Generated fresh for each auth attempt
     var isRegisteredClient: Bool = false  // Track if we've dynamically registered
 

--- a/Context/Context/Authentication/AuthenticationView.swift
+++ b/Context/Context/Authentication/AuthenticationView.swift
@@ -201,16 +201,17 @@ struct AuthenticationView: View {
 
     Task {
       do {
+        let urlScheme = OAuthConstants.urlScheme
         let result = try await webAuthenticationSession.authenticate(
           using: authURL,
-          callbackURLScheme: "context",
+          callbackURLScheme: urlScheme,
           preferredBrowserSession: .shared
         )
 
         // Validate callback URL structure
-        guard result.scheme == "context",
-          result.host == "oauth",
-          result.path == "/callback"
+        guard result.scheme == urlScheme,
+          result.host == OAuthConstants.callbackHost,
+          result.path == OAuthConstants.callbackPath
         else {
           store.send(
             .metadataLoadFailed(

--- a/Context/Context/Common/OAuthConstants.swift
+++ b/Context/Context/Common/OAuthConstants.swift
@@ -1,0 +1,19 @@
+// Copyright © 2025 Indragie Karunaratne. All rights reserved.
+
+import Foundation
+
+enum OAuthConstants {
+  static let callbackURL = URL(string: "app.contextmcp://oauth/callback")!
+  
+  static var urlScheme: String {
+    callbackURL.scheme!
+  }
+  
+  static var callbackHost: String {
+    callbackURL.host!
+  }
+  
+  static var callbackPath: String {
+    callbackURL.path
+  }
+}

--- a/Context/Context/Info.plist
+++ b/Context/Context/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>SUPublicEDKey</key>
-	<string>oHCnTChJwkguvr4nCfAJupUglweocNBqjRXu3b7NLoU=</string>
-	<key>SUFeedURL</key>
-	<string>https://stats.store/api/v1/appcast/appcast.xml</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -34,9 +30,13 @@
 			<string>com.indragie.Context</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>context</string>
+				<string>app.contextmcp</string>
 			</array>
 		</dict>
 	</array>
+	<key>SUFeedURL</key>
+	<string>https://stats.store/api/v1/appcast/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>oHCnTChJwkguvr4nCfAJupUglweocNBqjRXu3b7NLoU=</string>
 </dict>
 </plist>

--- a/Context/Context/OAuth/OAuthCallbackHandler.swift
+++ b/Context/Context/OAuth/OAuthCallbackHandler.swift
@@ -4,7 +4,7 @@ import Foundation
 import SwiftUI
 import os
 
-/// Handles OAuth callback URLs for the context:// URL scheme.
+/// Handles OAuth callback URLs for the app.contextmcp:// URL scheme.
 @MainActor
 @Observable
 final class OAuthCallbackHandler {
@@ -26,13 +26,13 @@ final class OAuthCallbackHandler {
 
   /// Handles an OAuth callback URL.
   ///
-  /// Expected format: context://oauth/callback?code=XXX&state=YYY
-  /// or error format: context://oauth/callback?error=XXX&error_description=YYY&state=ZZZ
+  /// Expected format: app.contextmcp://oauth/callback?code=XXX&state=YYY
+  /// or error format: app.contextmcp://oauth/callback?error=XXX&error_description=YYY&state=ZZZ
   func handleURL(_ url: URL) -> Bool {
     // Strict validation of callback URL structure
-    guard url.scheme == "context",
-      url.host == "oauth",
-      url.path == "/callback"
+    guard url.scheme == OAuthConstants.urlScheme,
+      url.host == OAuthConstants.callbackHost,
+      url.path == OAuthConstants.callbackPath
     else {
       logger.warning("Received URL with incorrect structure: \(url, privacy: .private)")
       return false

--- a/ContextCore/Tests/ContextCoreTests/OAuthClientTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/OAuthClientTests.swift
@@ -385,7 +385,7 @@ class MockURLProtocol: URLProtocol {
         code: "invalid_code",
         authServerMetadata: authServerMetadata,
         clientID: "test_client",
-        redirectURI: "context://oauth/callback",
+        redirectURI: "app.contextmcp://oauth/callback",
         pkce: pkce,
         resource: nil
       )
@@ -440,7 +440,7 @@ class MockURLProtocol: URLProtocol {
         code: "valid_code",
         authServerMetadata: authServerMetadata,
         clientID: "test_client",
-        redirectURI: "context://oauth/callback",
+        redirectURI: "app.contextmcp://oauth/callback",
         pkce: pkce,
         resource: nil
       )
@@ -533,7 +533,7 @@ class MockURLProtocol: URLProtocol {
     )
 
     let registrationRequest = ClientRegistrationRequest(
-      redirectUris: ["context://oauth/callback"],
+      redirectUris: ["app.contextmcp://oauth/callback"],
       clientName: "Context MCP Client",
       scope: "read write",
       grantTypes: ["authorization_code", "refresh_token"],
@@ -553,7 +553,7 @@ class MockURLProtocol: URLProtocol {
       // Verify request body
       if let body = request.httpBody {
         let decodedRequest = try JSONDecoder().decode(ClientRegistrationRequest.self, from: body)
-        #expect(decodedRequest.redirectUris == ["context://oauth/callback"])
+        #expect(decodedRequest.redirectUris == ["app.contextmcp://oauth/callback"])
         #expect(decodedRequest.clientName == "Context MCP Client")
       }
 
@@ -562,7 +562,7 @@ class MockURLProtocol: URLProtocol {
           "client_id": "dynamic_client_id_123",
           "client_secret": null,
           "client_id_issued_at": 1234567890,
-          "redirect_uris": ["context://oauth/callback"],
+          "redirect_uris": ["app.contextmcp://oauth/callback"],
           "client_name": "Context MCP Client",
           "scope": "read write",
           "grant_types": ["authorization_code", "refresh_token"],
@@ -591,7 +591,7 @@ class MockURLProtocol: URLProtocol {
     #expect(registrationResponse.clientId == "dynamic_client_id_123")
     #expect(registrationResponse.clientSecret == nil)
     #expect(registrationResponse.clientIdIssuedAt == 1_234_567_890)
-    #expect(registrationResponse.redirectUris == ["context://oauth/callback"])
+    #expect(registrationResponse.redirectUris == ["app.contextmcp://oauth/callback"])
     #expect(registrationResponse.clientName == "Context MCP Client")
     #expect(registrationResponse.tokenEndpointAuthMethod == "none")
 
@@ -614,7 +614,7 @@ class MockURLProtocol: URLProtocol {
     )
 
     let registrationRequest = ClientRegistrationRequest(
-      redirectUris: ["context://oauth/callback", "https://malicious.com/callback"],
+      redirectUris: ["app.contextmcp://oauth/callback", "https://malicious.com/callback"],
       clientName: "Context MCP Client"
     )
 
@@ -675,7 +675,7 @@ class MockURLProtocol: URLProtocol {
     )
 
     let registrationRequest = ClientRegistrationRequest(
-      redirectUris: ["context://oauth/callback"],
+      redirectUris: ["app.contextmcp://oauth/callback"],
       clientName: "Context MCP Client"
     )
 
@@ -713,7 +713,7 @@ class MockURLProtocol: URLProtocol {
     )
 
     let registrationRequest = ClientRegistrationRequest(
-      redirectUris: ["context://oauth/callback"],
+      redirectUris: ["app.contextmcp://oauth/callback"],
       clientName: "Context MCP Client",
       grantTypes: ["unsupported_grant_type"]  // Invalid grant type
     )
@@ -774,7 +774,7 @@ class MockURLProtocol: URLProtocol {
     )
 
     let registrationRequest = ClientRegistrationRequest(
-      redirectUris: ["context://oauth/callback"],
+      redirectUris: ["app.contextmcp://oauth/callback"],
       clientName: "Context MCP Client",
       grantTypes: ["authorization_code", "client_credentials"],
       tokenEndpointAuthMethod: "client_secret_basic"  // Requesting confidential client
@@ -790,7 +790,7 @@ class MockURLProtocol: URLProtocol {
           "client_secret": "super_secret_password_789",
           "client_id_issued_at": 1234567890,
           "client_secret_expires_at": 0,
-          "redirect_uris": ["context://oauth/callback"],
+          "redirect_uris": ["app.contextmcp://oauth/callback"],
           "client_name": "Context MCP Client",
           "grant_types": ["authorization_code", "client_credentials"],
           "token_endpoint_auth_method": "client_secret_basic"

--- a/ContextCore/Tests/ContextCoreTests/OAuthClientTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/OAuthClientTests.swift
@@ -503,7 +503,7 @@ class MockURLProtocol: URLProtocol {
       code: "auth_code_from_third_party",
       authServerMetadata: authServerMetadata,
       clientID: "com.indragie.Context",
-      redirectURI: "context://oauth/callback",
+      redirectURI: "app.contextmcp://oauth/callback",
       pkce: pkce,
       resource: URL(string: "https://mcp.example.com/api")!
     )


### PR DESCRIPTION
Some OAuth implementations require the scheme to contain a period (.) to be valid