### PR TITLE
Split resources & resource templates and add pagination support

### DIFF
--- a/Context/Context/Prompts/PromptsView.swift
+++ b/Context/Context/Prompts/PromptsView.swift
@@ -38,21 +38,30 @@ struct PromptsView: View {
             description: Text("No prompts match '\(viewStore.searchQuery)'")
           )
         } else {
-          List(
-            viewStore.filteredPrompts,
-            selection: viewStore.binding(
-              get: \.selectedPromptName,
-              send: PromptsFeature.Action.promptSelected
-            )
-          ) { prompt in
-            PromptRow(
-              prompt: prompt,
-              isSelected: viewStore.selectedPromptName == prompt.name
-            )
-            .contextMenu {
-              Button("Copy Name") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(prompt.name, forType: .string)
+          ScrollViewReader { proxy in
+            List(
+              viewStore.filteredPrompts,
+              selection: viewStore.binding(
+                get: \.selectedPromptName,
+                send: PromptsFeature.Action.promptSelected
+              )
+            ) { prompt in
+              PromptRow(
+                prompt: prompt,
+                isSelected: viewStore.selectedPromptName == prompt.name
+              )
+              .id(prompt.name)
+              .contextMenu {
+                Button("Copy Name") {
+                  NSPasteboard.general.clearContents()
+                  NSPasteboard.general.setString(prompt.name, forType: .string)
+                }
+              }
+            }
+            .onChange(of: viewStore.searchQuery) { _, _ in
+              // Reset scroll position to top for any search query change
+              if let firstPrompt = viewStore.filteredPrompts.first {
+                proxy.scrollTo(firstPrompt.name, anchor: .top)
               }
             }
           }

--- a/Context/Context/Resources/ResourcesView.swift
+++ b/Context/Context/Resources/ResourcesView.swift
@@ -85,6 +85,17 @@ struct ResourcesView: View {
                         NSPasteboard.general.setString(resource.uri, forType: .string)
                       }
                     }
+                    .onAppear {
+                      // Load more when we're 5 items from the end
+                      let bufferSize = 5
+                      if let index = viewStore.filteredResources.firstIndex(where: {
+                        $0.id == resource.id
+                      }),
+                        index >= viewStore.filteredResources.count - bufferSize
+                      {
+                        viewStore.send(.loadMoreResources)
+                      }
+                    }
                   }
                 } else {
                   // Show only templates
@@ -105,7 +116,47 @@ struct ResourcesView: View {
                         NSPasteboard.general.setString(template.uriTemplate, forType: .string)
                       }
                     }
+                    .onAppear {
+                      // Load more when we're 5 items from the end
+                      let bufferSize = 5
+                      if let index = viewStore.filteredResourceTemplates.firstIndex(where: {
+                        $0.id == template.id
+                      }),
+                        index >= viewStore.filteredResourceTemplates.count - bufferSize
+                      {
+                        viewStore.send(.loadMoreTemplates)
+                      }
+                    }
                   }
+                }
+
+                // Show loading indicator when fetching more items
+                if viewStore.selectedSegment == .resources && viewStore.isLoadingMoreResources {
+                  HStack {
+                    Spacer()
+                    ProgressView()
+                      .scaleEffect(0.8)
+                    Text("Loading more resources...")
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                    Spacer()
+                  }
+                  .padding(.vertical, 8)
+                  .id("resources-loading-more")
+                } else if viewStore.selectedSegment == .templates
+                  && viewStore.isLoadingMoreTemplates
+                {
+                  HStack {
+                    Spacer()
+                    ProgressView()
+                      .scaleEffect(0.8)
+                    Text("Loading more templates...")
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                    Spacer()
+                  }
+                  .padding(.vertical, 8)
+                  .id("templates-loading-more")
                 }
               }
               .onChange(of: viewStore.searchQuery) { _, _ in

--- a/Context/Context/Resources/ResourcesView.swift
+++ b/Context/Context/Resources/ResourcesView.swift
@@ -64,43 +64,59 @@ struct ResourcesView: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
           } else {
-            List(selection: $selection) {
-              if viewStore.selectedSegment == .resources {
-                // Show only resources
-                ForEach(viewStore.filteredResources) { resource in
-                  ResourceRow(
-                    name: resource.name,
-                    description: resource.description,
-                    uri: resource.uri,
-                    mimeType: resource.mimeType,
-                    isTemplate: false,
-                    isSelected: viewStore.selectedResourceID == resource.id
-                  )
-                  .tag(resource.id)
-                  .contextMenu {
-                    Button("Copy URI") {
-                      NSPasteboard.general.clearContents()
-                      NSPasteboard.general.setString(resource.uri, forType: .string)
+            ScrollViewReader { proxy in
+              List(selection: $selection) {
+                if viewStore.selectedSegment == .resources {
+                  // Show only resources
+                  ForEach(viewStore.filteredResources) { resource in
+                    ResourceRow(
+                      name: resource.name,
+                      description: resource.description,
+                      uri: resource.uri,
+                      mimeType: resource.mimeType,
+                      isTemplate: false,
+                      isSelected: viewStore.selectedResourceID == resource.id
+                    )
+                    .tag(resource.id)
+                    .id(resource.id)
+                    .contextMenu {
+                      Button("Copy URI") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(resource.uri, forType: .string)
+                      }
+                    }
+                  }
+                } else {
+                  // Show only templates
+                  ForEach(viewStore.filteredResourceTemplates) { template in
+                    ResourceRow(
+                      name: template.name,
+                      description: template.description,
+                      uri: template.uriTemplate,
+                      mimeType: template.mimeType,
+                      isTemplate: true,
+                      isSelected: viewStore.selectedResourceTemplateID == template.id
+                    )
+                    .tag(template.id)
+                    .id(template.id)
+                    .contextMenu {
+                      Button("Copy URI Template") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(template.uriTemplate, forType: .string)
+                      }
                     }
                   }
                 }
-              } else {
-                // Show only templates
-                ForEach(viewStore.filteredResourceTemplates) { template in
-                  ResourceRow(
-                    name: template.name,
-                    description: template.description,
-                    uri: template.uriTemplate,
-                    mimeType: template.mimeType,
-                    isTemplate: true,
-                    isSelected: viewStore.selectedResourceTemplateID == template.id
-                  )
-                  .tag(template.id)
-                  .contextMenu {
-                    Button("Copy URI Template") {
-                      NSPasteboard.general.clearContents()
-                      NSPasteboard.general.setString(template.uriTemplate, forType: .string)
-                    }
+              }
+              .onChange(of: viewStore.searchQuery) { _, _ in
+                // Reset scroll position to top for any search query change
+                if viewStore.selectedSegment == .resources {
+                  if let firstResource = viewStore.filteredResources.first {
+                    proxy.scrollTo(firstResource.id, anchor: .top)
+                  }
+                } else {
+                  if let firstTemplate = viewStore.filteredResourceTemplates.first {
+                    proxy.scrollTo(firstTemplate.id, anchor: .top)
                   }
                 }
               }

--- a/Context/Context/Tools/ToolsView.swift
+++ b/Context/Context/Tools/ToolsView.swift
@@ -39,18 +39,27 @@ struct ToolsView: View {
             description: Text("No tools match '\(viewStore.searchQuery)'")
           )
         } else {
-          List(
-            viewStore.filteredTools,
-            selection: $selection
-          ) { tool in
-            ToolRow(
-              tool: tool,
-              isSelected: viewStore.selectedToolName == tool.name
-            )
-            .contextMenu {
-              Button("Copy Name") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(tool.name, forType: .string)
+          ScrollViewReader { proxy in
+            List(
+              viewStore.filteredTools,
+              selection: $selection
+            ) { tool in
+              ToolRow(
+                tool: tool,
+                isSelected: viewStore.selectedToolName == tool.name
+              )
+              .id(tool.name)
+              .contextMenu {
+                Button("Copy Name") {
+                  NSPasteboard.general.clearContents()
+                  NSPasteboard.general.setString(tool.name, forType: .string)
+                }
+              }
+            }
+            .onChange(of: viewStore.searchQuery) { _, _ in
+              // Reset scroll position to top for any search query change
+              if let firstTool = viewStore.filteredTools.first {
+                proxy.scrollTo(firstTool.name, anchor: .top)
               }
             }
           }

--- a/Context/Context/Tools/ToolsView.swift
+++ b/Context/Context/Tools/ToolsView.swift
@@ -55,6 +55,30 @@ struct ToolsView: View {
                   NSPasteboard.general.setString(tool.name, forType: .string)
                 }
               }
+              .onAppear {
+                // Load more when we're 5 items from the end
+                let bufferSize = 5
+                if let index = viewStore.filteredTools.firstIndex(where: { $0.name == tool.name }),
+                  index >= viewStore.filteredTools.count - bufferSize
+                {
+                  viewStore.send(.loadMoreTools)
+                }
+              }
+
+              // Show loading indicator when fetching more items
+              if viewStore.isLoadingMore {
+                HStack {
+                  Spacer()
+                  ProgressView()
+                    .scaleEffect(0.8)
+                  Text("Loading more tools...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                  Spacer()
+                }
+                .padding(.vertical, 8)
+                .id("tools-loading-more")
+              }
             }
             .onChange(of: viewStore.searchQuery) { _, _ in
               // Reset scroll position to top for any search query change


### PR DESCRIPTION
- Splits the single list of resources & resource templates into two separate views with a segmented control
- Implement MCP Pagination support for tools, prompts, resources, and resource templates