### PR TITLE
Allow nil params and add ping to RequestRegistry

### DIFF
--- a/ContextCore/Sources/ContextCore/JSONRPC.swift
+++ b/ContextCore/Sources/ContextCore/JSONRPC.swift
@@ -148,7 +148,7 @@ public protocol JSONRPCRequest: Codable, Sendable {
 
   var jsonrpc: String { get }
   var method: String { get }
-  var params: Params { get }
+  var params: Params? { get }
   var id: JSONRPCRequestID { get }
   var responseDecoder: ResponseDecoder { get }
 }
@@ -158,7 +158,7 @@ public protocol JSONRPCNotification: Codable, Sendable {
 
   var jsonrpc: String { get }
   var method: String { get }
-  var params: Params { get }
+  var params: Params? { get }
 }
 
 public protocol JSONRPCResponse: Codable, Sendable {

--- a/ContextCore/Sources/ContextCore/Transport.swift
+++ b/ContextCore/Sources/ContextCore/Transport.swift
@@ -243,7 +243,8 @@ private enum NotificationRegistry {
 // Registry of request types that can be decoded (for server-initiated requests)
 private enum RequestRegistry {
   private static let types: [String: any JSONRPCRequest.Type] = [
-    "sampling/createMessage": CreateMessageRequest.self
+    "sampling/createMessage": CreateMessageRequest.self,
+    "ping": PingRequest.self
   ]
 
   static func requestType(for method: String) -> (any JSONRPCRequest.Type)? {

--- a/ContextCore/Tests/ContextCoreTests/ClientTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/ClientTests.swift
@@ -540,7 +540,8 @@ private actor MockSamplingHandler: SamplingHandler {
   private(set) var wasCalledWithExpectedMessage = false
 
   func sample(_ request: CreateMessageRequest) async throws -> CreateMessageResponse.Result {
-    if let firstMessage = request.params.messages.first,
+    if let params = request.params,
+      let firstMessage = params.messages.first,
       case .text(let text, _) = firstMessage.content,
       text.contains("Please provide a creative response to this message: Hello World")
     {

--- a/ContextCore/Tests/ContextCoreTests/JSONRPCMacrosTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/JSONRPCMacrosTests.swift
@@ -40,7 +40,7 @@ final class JSONRPCMacrosTests: XCTestCase {
 
               public let method: String
 
-              public let params: Params
+              public let params: Params?
 
               public let id: JSONRPCRequestID
 
@@ -65,15 +65,25 @@ final class JSONRPCMacrosTests: XCTestCase {
               public typealias Response = TestResponse
 
               public var debugDescription: String {
-                  \"\"\"
-                  TestRequest {
-                      method="\\(method)",
-                      id=\\(String(reflecting: id)),
-                      params={
-                          name=\\(String(reflecting: self.params.name))
+                  if let params = self.params {
+                      return \"\"\"
+                      TestRequest {
+                          method="\\(method)",
+                          id=\\(String(reflecting: id)),
+                          params={
+                              name=\\(String(reflecting: params.name))
+                          }
                       }
+                      \"\"\"
+                  } else {
+                      return \"\"\"
+                      TestRequest {
+                          method="\\(method)",
+                          id=\\(String(reflecting: id)),
+                          params=nil
+                      }
+                      \"\"\"
                   }
-                  \"\"\"
               }
 
               public var description: String {
@@ -118,7 +128,7 @@ final class JSONRPCMacrosTests: XCTestCase {
 
               public let method: String
 
-              public let params: Params
+              public let params: Params?
 
               public init(name: String) {
                   self.jsonrpc = "2.0"
@@ -133,14 +143,23 @@ final class JSONRPCMacrosTests: XCTestCase {
               }
 
               public var debugDescription: String {
-                  \"\"\"
-                  TestNotification {
-                      method=\"\\(method)\",
-                      params={
-                          name=\\(String(reflecting: self.params.name))
+                  if let params = self.params {
+                      return \"\"\"
+                      TestNotification {
+                          method=\"\\(method)\",
+                          params={
+                              name=\\(String(reflecting: params.name))
+                          }
                       }
+                      \"\"\"
+                  } else {
+                      return \"\"\"
+                      TestNotification {
+                          method=\"\\(method)\",
+                          params=nil
+                      }
+                      \"\"\"
                   }
-                  \"\"\"
               }
 
               public var description: String {

--- a/ContextCore/Tests/ContextCoreTests/SchemaTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/SchemaTests.swift
@@ -216,9 +216,9 @@ extension Encodable {
 
     #expect(decoded.jsonrpc == "2.0")
     #expect(decoded.method == "initialize")
-    #expect(decoded.params.protocolVersion == "2025-03-26")
-    #expect(decoded.params.clientInfo.name == "Test Client")
-    #expect(decoded.params.clientInfo.version == "1.0.0")
+    #expect(decoded.params?.protocolVersion == "2025-03-26")
+    #expect(decoded.params?.clientInfo.name == "Test Client")
+    #expect(decoded.params?.clientInfo.version == "1.0.0")
 
     if case let .string(idValue) = decoded.id {
       #expect(idValue == "req-1")
@@ -258,7 +258,7 @@ extension Encodable {
       ListResourcesRequest.self, from: listRequestData)
 
     #expect(decodedListRequest.method == "resources/list")
-    #expect(decodedListRequest.params.cursor == nil)
+    #expect(decodedListRequest.params?.cursor == nil)
 
     // ReadResourceRequest
     let readRequest = ReadResourceRequest(id: .number(2), uri: "file:///example.txt")
@@ -267,7 +267,7 @@ extension Encodable {
       ReadResourceRequest.self, from: readRequestData)
 
     #expect(decodedReadRequest.method == "resources/read")
-    #expect(decodedReadRequest.params.uri == "file:///example.txt")
+    #expect(decodedReadRequest.params?.uri == "file:///example.txt")
 
     // ReadResourceResponse
     let contents: [EmbeddedResource] = [
@@ -301,7 +301,7 @@ extension Encodable {
     let decodedCancelled = try JSONDecoder().decode(CancelledNotification.self, from: cancelledData)
 
     #expect(decodedCancelled.method == "notifications/cancelled")
-    #expect(decodedCancelled.params.requestId == .number(123))
+    #expect(decodedCancelled.params?.requestId == .number(123))
 
     // ProgressNotification
     let progressNotification = ProgressNotification(
@@ -314,9 +314,9 @@ extension Encodable {
     let decodedProgress = try JSONDecoder().decode(ProgressNotification.self, from: progressData)
 
     #expect(decodedProgress.method == "notifications/progress")
-    #expect(decodedProgress.params.id == .string("req-456"))
-    #expect(decodedProgress.params.progress == 0.75)
-    #expect(decodedProgress.params.message == "Loading resources...")
+    #expect(decodedProgress.params?.id == .string("req-456"))
+    #expect(decodedProgress.params?.progress == 0.75)
+    #expect(decodedProgress.params?.message == "Loading resources...")
   }
 
   @Test func testLoggingEncodingDecoding() async throws {
@@ -326,7 +326,7 @@ extension Encodable {
     let decodedSetLevel = try JSONDecoder().decode(SetLevelRequest.self, from: setLevelData)
 
     #expect(decodedSetLevel.method == "logging/setLevel")
-    #expect(decodedSetLevel.params.level == .debug)
+    #expect(decodedSetLevel.params?.level == .debug)
 
     // LoggingMessageNotification
     let loggingNotification = LoggingMessageNotification(
@@ -340,10 +340,10 @@ extension Encodable {
       LoggingMessageNotification.self, from: loggingData)
 
     #expect(decodedLogging.method == "notifications/message")
-    #expect(decodedLogging.params.level == .info)
-    #expect(decodedLogging.params.logger == "AppLogger")
+    #expect(decodedLogging.params?.level == .info)
+    #expect(decodedLogging.params?.logger == "AppLogger")
 
-    if case let .string(message) = decodedLogging.params.data {
+    if case let .string(message) = decodedLogging.params?.data {
       #expect(message == "This is a log message")
     } else {
       Issue.record("Log data is not a string")
@@ -363,9 +363,9 @@ extension Encodable {
     let decodedCallRequest = try JSONDecoder().decode(CallToolRequest.self, from: callRequestData)
 
     #expect(decodedCallRequest.method == "tools/call")
-    #expect(decodedCallRequest.params.name == "search")
-    #expect(decodedCallRequest.params.arguments?["query"] == .string("How to make pasta"))
-    #expect(decodedCallRequest.params.arguments?["limit"] == .integer(5))
+    #expect(decodedCallRequest.params?.name == "search")
+    #expect(decodedCallRequest.params?.arguments?["query"] == .string("How to make pasta"))
+    #expect(decodedCallRequest.params?.arguments?["limit"] == .integer(5))
 
     // CallToolResponse
     let content: [Content] = [
@@ -467,15 +467,15 @@ extension Encodable {
       CreateMessageRequest.self, from: createRequestData)
 
     #expect(decodedCreateRequest.method == "sampling/createMessage")
-    #expect(decodedCreateRequest.params.messages.count == 1)
-    #expect(decodedCreateRequest.params.messages[0].role == .user)
-    #expect(decodedCreateRequest.params.temperature == 0.7)
-    #expect(decodedCreateRequest.params.maxTokens == 1000)
-    #expect(decodedCreateRequest.params.systemPrompt == "You are a helpful assistant.")
-    #expect(decodedCreateRequest.params.includeContext == .thisServer)
-    #expect(decodedCreateRequest.params.stopSequences?.count == 1)
-    #expect(decodedCreateRequest.params.stopSequences?[0] == "END")
-    #expect(decodedCreateRequest.params.modelPreferences?.costPriority == 0.3)
+    #expect(decodedCreateRequest.params?.messages.count == 1)
+    #expect(decodedCreateRequest.params?.messages[0].role == .user)
+    #expect(decodedCreateRequest.params?.temperature == 0.7)
+    #expect(decodedCreateRequest.params?.maxTokens == 1000)
+    #expect(decodedCreateRequest.params?.systemPrompt == "You are a helpful assistant.")
+    #expect(decodedCreateRequest.params?.includeContext == .thisServer)
+    #expect(decodedCreateRequest.params?.stopSequences?.count == 1)
+    #expect(decodedCreateRequest.params?.stopSequences?[0] == "END")
+    #expect(decodedCreateRequest.params?.modelPreferences?.costPriority == 0.3)
 
     // Test CreateMessageResponse
     let createResponse = CreateMessageResponse(

--- a/ContextCore/Tests/ContextCoreTests/StreamableHTTPTransportTests.swift
+++ b/ContextCore/Tests/ContextCoreTests/StreamableHTTPTransportTests.swift
@@ -479,9 +479,10 @@ import os
             case .successfulRequest:
               break
             case .serverNotification(let notification):
-              if let log = notification as? LoggingMessageNotification {
-                #expect(log.params.level == LoggingLevel.info)
-                if case let .string(message) = log.params.data {
+              if let log = notification as? LoggingMessageNotification,
+                 let params = log.params {
+                #expect(params.level == LoggingLevel.info)
+                if case let .string(message) = params.data {
                   #expect(message.contains("Running the echo tool"))
                   receivedLog()
                   return true


### PR DESCRIPTION
JSON-RPC allows params to be omitted:

> A Structured value that holds the parameter values to be used during the invocation of the method. **This member MAY be omitted.**

Previously, parsing was more strict and would fail if the member was omitted, but this change makes it optional.

In addition, the `ping` request has now been added to the `RequestRegistry` so an incoming ping from the server can be correctly parsed by the client.

Close #22

