### PR TITLE
Handle non-compliant OAuth servers returning 401 for metadata discovery

### DIFF
--- a/ContextCore/Sources/ContextCore/OAuthClient.swift
+++ b/ContextCore/Sources/ContextCore/OAuthClient.swift
@@ -447,8 +447,12 @@ public actor OAuthClient {
     let (data, response) = try await urlSession.data(for: resourceRequest)
 
     if let httpResponse = response as? HTTPURLResponse {
-      if httpResponse.statusCode == 404 {
-        logger.info("Resource metadata endpoint returned 404, using default authorization base URL")
+      if httpResponse.statusCode == 404 || httpResponse.statusCode == 401 {
+        if httpResponse.statusCode == 401 {
+          logger.warning("Resource metadata endpoint returned 401 - server is not spec-compliant. Treating as 404.")
+        } else {
+          logger.info("Resource metadata endpoint returned 404, using default authorization base URL")
+        }
         resourceMetadata = nil
 
         // Determine authorization base URL by removing path component from resource metadata URL


### PR DESCRIPTION
Some OAuth servers incorrectly return 401 Unauthorized instead of 404 Not Found when the protected resource metadata endpoint doesn't exist. According to OAuth specifications, metadata discovery endpoints should be publicly accessible.

This change treats 401 responses the same as 404 responses during metadata discovery, falling back to default endpoint paths. A warning is logged to indicate the server is not spec-compliant.

This fixes token refresh failures with servers like Sentry that return 401 for their .well-known/oauth-protected-resource endpoint.

🤖 Generated with [Claude Code](https://claude.ai/code)