### PR TITLE
Fix roots/list request parsing by adding missing RequestRegistry entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 * Show formatted error responses when calling tools, getting prompts, and getting resources fails (#31)
 * Add missing copy buttons for copying responses and errors as JSON (#31)
-* Fix stepper control in tool input incrementing by 0.1 instead of 1
-* Fix dropdown menus in tool input not persisting initial value
+* Fix stepper control in tool input incrementing by 0.1 instead of 1 (#31)
+* Fix dropdown menus in tool input not persisting initial value (#31)
+* Fix client not handling a roots/list request from the server (#33)
 
 ## Version 1.0.7 (107)
 

--- a/ContextCore/Sources/ContextCore/Transport.swift
+++ b/ContextCore/Sources/ContextCore/Transport.swift
@@ -244,7 +244,8 @@ private enum NotificationRegistry {
 private enum RequestRegistry {
   private static let types: [String: any JSONRPCRequest.Type] = [
     "sampling/createMessage": CreateMessageRequest.self,
-    "ping": PingRequest.self
+    "ping": PingRequest.self,
+    "roots/list": ListRootsRequest.self
   ]
 
   static func requestType(for method: String) -> (any JSONRPCRequest.Type)? {


### PR DESCRIPTION
This commit resolves issue #28 where the client would disconnect when receiving a roots/list request without parameters. The root cause was that the RequestRegistry was missing the entry for "roots/list": ListRootsRequest.self, causing the server to throw TransportError.unexpectedRequest when attempting to decode the request.

Changes:
- Added "roots/list": ListRootsRequest.self to RequestRegistry.types dictionary
- This allows the server to properly decode roots/list requests both with and without parameters
- The ListRootsRequest was already correctly defined with optional parameters via the @JSONRPCRequest macro

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)