### PR TITLE
Fix initialization regression caused by #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix regression (initialization delay when using Streamable HTTP) introduced in v1.0.8 (#38)
+
 ## Version 1.0.8 (108)
 
 * Show formatted error responses when calling tools, getting prompts, and getting resources fails (#31)


### PR DESCRIPTION
When using the streamable HTTP transport, the client should not block on opening the SSE stream as this is optional. We still need to block in the legacy HTTP+SSE case because the server needs to send the client the `endpoint` event over SSE before the client is initialized.

Close #37