### PR TITLE
Fetch MCP metadata from /.well-known/mcp.json

### DIFF
--- a/Context/Context.xcodeproj/project.pbxproj
+++ b/Context/Context.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		033742732E0E7555000CB545 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 033742722E0E7555000CB545 /* ZIPFoundation */; };
 		033C2B3C2DF009CE00759652 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 033C2B3B2DF009CE00759652 /* MarkdownUI */; };
 		033FB0C72E261C2E001DE211 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = 033FB0C62E261C2E001DE211 /* CodeEditSourceEditor */; };
+		033FC73D2E2AFC2F001C38E9 /* SVGView in Frameworks */ = {isa = PBXBuildFile; productRef = 033FC73C2E2AFC2F001C38E9 /* SVGView */; };
 		0382543D2DEA3B890096CC9D /* HighlightSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0382543C2DEA3B890096CC9D /* HighlightSwift */; };
 		0382544C2DEA6B8F0096CC9D /* SharingGRDB in Frameworks */ = {isa = PBXBuildFile; productRef = 0382544B2DEA6B8F0096CC9D /* SharingGRDB */; };
 		039334FE2DE7C90500ABB09C /* ContextCore in Frameworks */ = {isa = PBXBuildFile; productRef = 039334FD2DE7C90500ABB09C /* ContextCore */; };
@@ -85,6 +86,7 @@
 				0382544C2DEA6B8F0096CC9D /* SharingGRDB in Frameworks */,
 				033C2B3C2DF009CE00759652 /* MarkdownUI in Frameworks */,
 				039335012DE7C97500ABB09C /* ComposableArchitecture in Frameworks */,
+				033FC73D2E2AFC2F001C38E9 /* SVGView in Frameworks */,
 				03C8520B2E0337AB00869408 /* SentrySwiftUI in Frameworks */,
 				03C852092E0337AB00869408 /* Sentry in Frameworks */,
 				0382543D2DEA3B890096CC9D /* HighlightSwift in Frameworks */,
@@ -161,6 +163,7 @@
 				03DE6A832E0BB6F1004A32EE /* Sparkle */,
 				033742722E0E7555000CB545 /* ZIPFoundation */,
 				033FB0C62E261C2E001DE211 /* CodeEditSourceEditor */,
+				033FC73C2E2AFC2F001C38E9 /* SVGView */,
 			);
 			productName = Context;
 			productReference = 03170A0F2DD121420037EE9A /* Context.app */;
@@ -254,6 +257,7 @@
 				03DE6A822E0BB6F1004A32EE /* XCRemoteSwiftPackageReference "Sparkle" */,
 				033742712E0E7555000CB545 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				033FB0C52E261C2E001DE211 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */,
+				033FC73B2E2AFC2F001C38E9 /* XCRemoteSwiftPackageReference "SVGView" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 03170A102DD121420037EE9A /* Products */;
@@ -698,6 +702,14 @@
 				minimumVersion = 0.14.1;
 			};
 		};
+		033FC73B2E2AFC2F001C38E9 /* XCRemoteSwiftPackageReference "SVGView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/exyte/SVGView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.6;
+			};
+		};
 		0382543B2DEA3B890096CC9D /* XCRemoteSwiftPackageReference "HighlightSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/appstefan/HighlightSwift";
@@ -759,6 +771,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 033FB0C52E261C2E001DE211 /* XCRemoteSwiftPackageReference "CodeEditSourceEditor" */;
 			productName = CodeEditSourceEditor;
+		};
+		033FC73C2E2AFC2F001C38E9 /* SVGView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 033FC73B2E2AFC2F001C38E9 /* XCRemoteSwiftPackageReference "SVGView" */;
+			productName = SVGView;
 		};
 		0382543C2DEA3B890096CC9D /* HighlightSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Context/Context.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Context/Context.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f5a0ddf502a99a0fbca915371465206c7da0e4e04d7681e964462252c93fc0bb",
+  "originHash" : "3e17435b2de291a5e27c7c178824ac36b9548fcb26f5e7b73757606f0255713d",
   "pins" : [
     {
       "identity" : "codeeditlanguages",
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "df074165274afaa39539c05d57b0832620775b11",
         "version" : "2.7.1"
+      }
+    },
+    {
+      "identity" : "svgview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/SVGView",
+      "state" : {
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
       }
     },
     {
@@ -283,7 +292,7 @@
     {
       "identity" : "swifttreesitter",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter.git",
+      "location" : "https://github.com/ChimeHQ/SwiftTreeSitter",
       "state" : {
         "revision" : "08ef81eb8620617b55b08868126707ad72bf754f",
         "version" : "0.25.0"

--- a/Context/Context/AddServer/Services/MCPMetadata.swift
+++ b/Context/Context/AddServer/Services/MCPMetadata.swift
@@ -1,0 +1,10 @@
+// Copyright © 2025 Indragie Karunaratne. All rights reserved.
+
+import Foundation
+
+struct MCPMetadata: Codable, Equatable {
+  let name: String?
+  let description: String?
+  let icon: String?
+  let endpoint: String
+}

--- a/Context/Context/AddServer/Services/MCPMetadataService.swift
+++ b/Context/Context/AddServer/Services/MCPMetadataService.swift
@@ -1,0 +1,70 @@
+// Copyright © 2025 Indragie Karunaratne. All rights reserved.
+
+import Dependencies
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.indragie.Context", category: "MCPMetadataService")
+
+struct MCPMetadataService {
+  var fetchMetadata: @Sendable (_ url: URL) async throws -> MCPMetadata
+}
+
+extension MCPMetadataService: DependencyKey {
+  static var liveValue: MCPMetadataService {
+    MCPMetadataService(
+      fetchMetadata: { url in
+        logger.debug("Fetching MCP metadata from: \(url.absoluteString)")
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+          throw MCPMetadataError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+          throw MCPMetadataError.httpError(statusCode: httpResponse.statusCode)
+        }
+
+        let metadata = try JSONDecoder().decode(MCPMetadata.self, from: data)
+        logger.debug("Successfully fetched MCP metadata: \(String(describing: metadata.name))")
+
+        return metadata
+      }
+    )
+  }
+
+  static var testValue: MCPMetadataService {
+    MCPMetadataService(
+      fetchMetadata: { _ in
+        MCPMetadata(
+          name: "Test Server",
+          description: "Test Description",
+          icon: "https://example.com/icon.png",
+          endpoint: "https://example.com/mcp"
+        )
+      }
+    )
+  }
+}
+
+extension DependencyValues {
+  var mcpMetadataService: MCPMetadataService {
+    get { self[MCPMetadataService.self] }
+    set { self[MCPMetadataService.self] = newValue }
+  }
+}
+
+enum MCPMetadataError: LocalizedError {
+  case invalidResponse
+  case httpError(statusCode: Int)
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidResponse:
+      return "Invalid response from server"
+    case .httpError(let statusCode):
+      return "HTTP error: \(statusCode)"
+    }
+  }
+}

--- a/Context/Context/AddServer/Transports/HTTP/HTTPConfigFeature.swift
+++ b/Context/Context/AddServer/Transports/HTTP/HTTPConfigFeature.swift
@@ -1,7 +1,9 @@
 // Copyright © 2025 Indragie Karunaratne. All rights reserved.
 
 import ComposableArchitecture
+import Dependencies
 import Foundation
+import os
 
 @Reducer
 struct HTTPConfigFeature {
@@ -12,6 +14,13 @@ struct HTTPConfigFeature {
     var headers = KeyValueListFeature.State(
       placeholder: KeyValueListFeature.Placeholder(key: "Authorization", value: ""))
     var urlAutoUpdate: Bool = true
+
+    // MCP metadata state
+    var mcpMetadata: MCPMetadata?
+    var isFetchingMetadata: Bool = false
+    var metadataFetchError: String?
+    var resolvedEndpointUrl: String?
+    var mcpMetadataUrl: String?
 
     init() {}
 
@@ -41,6 +50,21 @@ struct HTTPConfigFeature {
     case urlChanged(String)
     case setURLAutoUpdate(Bool)
     case headers(KeyValueListFeature.Action)
+
+    // MCP metadata actions
+    case fetchMetadata
+    case metadataFetched(Result<MCPMetadata, any Error>, metadataUrl: String)
+    case clearMetadata
+
+    // Internal actions
+    case debouncedFetchMetadata
+  }
+
+  @Dependency(\.mcpMetadataService) var mcpMetadataService
+  private let logger = Logger(subsystem: "com.indragie.Context", category: "HTTPConfigFeature")
+
+  private enum CancelID {
+    case fetchMetadata
   }
 
   var body: some ReducerOf<Self> {
@@ -52,13 +76,108 @@ struct HTTPConfigFeature {
       switch action {
       case let .urlChanged(url):
         state.url = url
-        return .none
+
+        // Check if we should fetch metadata
+        guard let urlComponents = URLComponents(string: url),
+          urlComponents.scheme != nil,
+          urlComponents.host != nil
+        else {
+          // Invalid URL, clear metadata if it exists
+          if state.mcpMetadata != nil {
+            return .send(.clearMetadata)
+          }
+          return .none
+        }
+
+        // Check if the path is empty or just "/"
+        let path = urlComponents.path
+        if path.isEmpty || path == "/" {
+          // Schedule debounced fetch
+          return .concatenate(
+            .cancel(id: CancelID.fetchMetadata),
+            .run { send in
+              try await Task.sleep(for: .milliseconds(500))
+              await send(.debouncedFetchMetadata)
+            }
+            .cancellable(id: CancelID.fetchMetadata)
+          )
+        } else {
+          // User specified a path, clear metadata if it exists
+          if state.mcpMetadata != nil {
+            return .send(.clearMetadata)
+          }
+          return .none
+        }
 
       case let .setURLAutoUpdate(enabled):
         state.urlAutoUpdate = enabled
         return .none
 
       case .headers:
+        return .none
+
+      case .debouncedFetchMetadata:
+        return .send(.fetchMetadata)
+
+      case .fetchMetadata:
+        guard let urlComponents = URLComponents(string: state.url),
+          let scheme = urlComponents.scheme,
+          let host = urlComponents.host
+        else {
+          return .none
+        }
+
+        // Build the well-known URL
+        var wellKnownComponents = URLComponents()
+        wellKnownComponents.scheme = scheme
+        wellKnownComponents.host = host
+        wellKnownComponents.port = urlComponents.port
+        wellKnownComponents.path = "/.well-known/mcp.json"
+
+        guard let wellKnownUrl = wellKnownComponents.url else {
+          return .none
+        }
+
+        state.isFetchingMetadata = true
+        state.metadataFetchError = nil
+
+        return .run { send in
+          do {
+            let metadata = try await mcpMetadataService.fetchMetadata(wellKnownUrl)
+            await send(
+              .metadataFetched(.success(metadata), metadataUrl: wellKnownUrl.absoluteString))
+          } catch {
+            // Silent failure as per requirements
+            logger.debug("Failed to fetch MCP metadata from \(wellKnownUrl): \(error)")
+            await send(.metadataFetched(.failure(error), metadataUrl: wellKnownUrl.absoluteString))
+          }
+        }
+
+      case let .metadataFetched(result, metadataUrl):
+        state.isFetchingMetadata = false
+
+        switch result {
+        case let .success(metadata):
+          state.mcpMetadata = metadata
+          state.resolvedEndpointUrl = metadata.endpoint
+          state.mcpMetadataUrl = metadataUrl
+          state.metadataFetchError = nil
+        case .failure:
+          // Silent failure - don't show error to user
+          state.mcpMetadata = nil
+          state.resolvedEndpointUrl = nil
+          state.mcpMetadataUrl = nil
+          state.metadataFetchError = nil
+        }
+
+        return .none
+
+      case .clearMetadata:
+        state.mcpMetadata = nil
+        state.resolvedEndpointUrl = nil
+        state.mcpMetadataUrl = nil
+        state.metadataFetchError = nil
+        state.isFetchingMetadata = false
         return .none
       }
     }

--- a/Context/Context/AddServer/Transports/HTTP/HTTPConfigView.swift
+++ b/Context/Context/AddServer/Transports/HTTP/HTTPConfigView.swift
@@ -1,6 +1,7 @@
 // Copyright © 2025 Indragie Karunaratne. All rights reserved.
 
 import ComposableArchitecture
+import SVGView
 import SwiftUI
 
 struct HTTPConfigView: View {
@@ -39,6 +40,64 @@ struct HTTPConfigView: View {
             + Text(" (legacy).")
             .font(.caption)
             .foregroundColor(.secondary)
+        }
+
+        // MCP Metadata Display
+        if let metadata = viewStore.mcpMetadata {
+          VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+              // Icon
+              if let iconUrlString = metadata.icon,
+                 let iconUrl = URL(string: iconUrlString) {
+                // Check if the icon is an SVG
+                if iconUrlString.lowercased().hasSuffix(".svg") {
+                  SVGView(contentsOf: iconUrl)
+                    .frame(width: 48, height: 48)
+                } else {
+                  AsyncImage(url: iconUrl) { image in
+                    image
+                      .resizable()
+                      .aspectRatio(contentMode: .fit)
+                  } placeholder: {
+                    Image(systemName: "globe")
+                      .foregroundColor(.secondary)
+                  }
+                  .frame(width: 48, height: 48)
+                }
+              } else {
+                // Default icon if no URL provided
+                Image(systemName: "globe")
+                  .foregroundColor(.secondary)
+                  .frame(width: 48, height: 48)
+              }
+              
+              // Name and Description
+              VStack(alignment: .leading, spacing: 4) {
+                if let name = metadata.name {
+                  Text(name)
+                    .font(.title3)
+                    .fontWeight(.medium)
+                }
+                
+                if let description = metadata.description {
+                  Text(description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+                }
+                
+                Text(metadata.endpoint)
+                  .font(.caption.monospaced())
+                  .foregroundColor(.blue)
+                  .textSelection(.enabled)
+              }
+              
+              Spacer()
+            }
+            .padding()
+            .background(Color(NSColor.controlBackgroundColor))
+            .cornerRadius(8)
+          }
         }
 
         // Headers

--- a/Context/Context/Database/Database.swift
+++ b/Context/Context/Database/Database.swift
@@ -92,6 +92,12 @@ func appDatabase() throws -> any DatabaseWriter {
     .execute(db)
   }
 
+  migrator.registerMigration("Add 'mcp_metadata_url' column to 'mcp_servers'") { db in
+    try db.alter(table: "mcp_servers") { t in
+      t.add(column: "mcp_metadata_url", .text)
+    }
+  }
+
   try migrator.migrate(dbWriter)
   return dbWriter
 }

--- a/Context/Context/Database/Schema.swift
+++ b/Context/Context/Database/Schema.swift
@@ -39,6 +39,9 @@ struct MCPServer: Equatable, Identifiable {
 
   @Column("dxt_user_config", as: DXTUserConfigurationValues?.JSONRepresentation.self)
   var dxtUserConfig: DXTUserConfigurationValues?
+
+  @Column("mcp_metadata_url")
+  var mcpMetadataUrl: String?
 }
 
 @Table("mcp_roots")


### PR DESCRIPTION
Not officially part of the MCP spec, but some servers are adopting it:

* https://www.notion.so/.well-known/mcp.json
* https://github.com/getsentry/sentry/pull/95934

<img width="3194" height="2294" alt="CleanShot 2025-07-18 at 15 12 09@2x" src="https://github.com/user-attachments/assets/5ebd4acd-31ae-443b-8dab-6b2be51030ee" />
